### PR TITLE
Fixed depthimage_to_laserscan_loader input image topic

### DIFF
--- a/launch/3dsensor.launch
+++ b/launch/3dsensor.launch
@@ -11,7 +11,7 @@
         <param name="scan_height" value="10"/>
         <param name="output_frame_id" value="/depth_camera_link"/>
         <param name="range_min" value="0.3"/>
-        <remap from="image" to="/depth/image_raw"/>
+        <remap from="image" to="depth/image_raw"/>
         <remap from="scan" to="/scan"/>
     </node>
   </group>


### PR DESCRIPTION
Forward slash (/) in front of "depth/image_raw" caused to look for topic in global namespace while topic is published under camera namespace.
